### PR TITLE
the return value of require("gulp-linker") is an empty object

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "https://github.com/filipsobczak/gulp-linker.git"
   },
-  "main": "gulpfile.js",
+  "main": "tasks/scriptlinker.js",
   "engines": {
     "node": ">= 0.8.0"
   },


### PR DESCRIPTION
not sure if this is the right fix
